### PR TITLE
Use config() in Provider instead of env()

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,19 @@ public function report(Exception $e)
 }
 ```
 
-Finally, add the following two configuration entries into .env. You can find your API key and project token on the project settings page for the project you wish to integrate.
+Add the following two configuration entries into .env. You can find your API key and project token on the project settings page for the project you wish to integrate.
 ```bash
 ERROR_STREAM_API_TOKEN=YOUR_API_TOKEN
 ERROR_STREAM_PROJECT_TOKEN=YOUR_PROJECT_TOKEN
 ```
 
+Finally, Add the errorstream config entries in your config/services.php
+```php
+'errorstream' => [
+    'api_token'    => env('ERROR_STREAM_API_TOKEN'),
+    'project_token' => env('ERROR_STREAM_PROJECT_TOKEN'),
+],
+```
 
 #Tagging
 Anywhere within your application you can append tags on to the reports that you generate and send to errorstream.com. Tags are great for grouping code together. You can make a call to add a tag anywhere by calling addTag(). A great place to do this would be to extend your Handler class modifications. For example:

--- a/src/ErrorStreamServiceProvider.php
+++ b/src/ErrorStreamServiceProvider.php
@@ -36,15 +36,15 @@ class ErrorStreamServiceProvider extends ServiceProvider
     {
         $this->app->singleton('errorstream', function ($app) {
             $client = new ErrorStreamClient();
-            $client->api_token = env('ERROR_STREAM_API_TOKEN');
-            $client->project_token = env('ERROR_STREAM_PROJECT_TOKEN');
+            $client->api_token = config('services.errorstream.api_token');
+            $client->project_token = config('services.errorstream.project_token');
             return $client;
         });
 
         $this->app->singleton('errorstreammonolog', function ($app) {
             $client = new ErrorStreamMonologHandler();
-            $client->api_token = env('ERROR_STREAM_API_TOKEN');
-            $client->project_token = env('ERROR_STREAM_PROJECT_TOKEN');
+            $client->api_token = config('services.errorstream.api_token');
+            $client->project_token = config('services.errorstream.project_token');
             return $client;
         });
     }


### PR DESCRIPTION
Since laravel 5.2 it is not recommended to use env() outside from the config files.
"If you are calling env from within your application, it is strongly recommended you add proper configuration values to your configuration files and call env from that location instead, allowing you to convert your env calls to config calls."

So I suggest to use the config() method inside the service provider and make an additional entry in a config file.
